### PR TITLE
lab/memory-gdb: Fix asserts that compare pointers instead of data

### DIFF
--- a/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
+++ b/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
@@ -5,28 +5,73 @@
 
 #define SIGN(X) (((X) > 0) - ((X) < 0))
 
+int test_strcpy(const char *src, size_t size);
+int test_memcpy(const char *src, size_t size);
+
+
 int my_strcmp(const char *s1, const char *s2);
 void *my_memcpy(void *dest, const void *src, size_t n);
 char *my_strcpy(char *dest, const char *src);
 
 int main() {
-	char s1[] = "Abracadabra";
-	char s2[] = "Abracababra";
-	char src[] = "Learn IOCLA, you must!";
-	char *dest = malloc(sizeof(src));
+    char s1[] = "Abracadabra";
+    char s2[] = "Abracababra";
+    char src[] = "Learn IOCLA, you must!";
 
-	(void) s1;
-	(void) s2;
+    (void) s1;
+    (void) s2;
 
-	/*
-	Decomentati pe rand cate un assert pe masura ce implementati o functie.
-	Daca functia voastra este implementata corect atunci asertia se va realiza
-	cu succes. In caz contrar, programul va crapa.
-	*/
-	// assert(SIGN(my_strcmp(s1, s2)) == SIGN(strcmp(s1, s2)));
-	// assert(my_memcpy(dest, src, sizeof(src)) == memcpy(dest, src, sizeof(src)));
-	// assert(my_strcpy(dest, src) == strcpy(dest, src));
-	free(dest);
+    /*
+    Decomentati pe rand cate un assert pe masura ce implementati o functie.
+    Daca functia voastra este implementata corect atunci asertia se va realiza
+    cu succes. In caz contrar, programul va crapa.
+    */
+    // assert(SIGN(my_strcmp(s1, s2)) == SIGN(strcmp(s1, s2)));
+    // assert(test_strcpy(src, sizeof(src)));
+    // assert(test_memcpy(src, sizeof(src)));
 
-	return 0;
+    return 0;
+}
+
+
+/* USED FOR TESTING! DO NOT MODIFY! */
+
+int test_strcpy(const char *src, size_t size) {
+    char *dest1 = malloc(size);
+    char *dest2 = malloc(size);
+
+    strcpy(dest1, src);
+    my_strcpy(dest2, src);
+
+    if (strcmp(dest1, dest2)) {
+        free(dest1);
+        free(dest2);
+        return 0;
+    }
+
+    free(dest1);
+    free(dest2);
+
+    return 1;
+}
+
+int test_memcpy(const char *src, size_t size) {
+    char *dest1 = malloc(size);
+    char *dest2 = malloc(size);
+
+    memcpy(dest1, src, size);
+    my_memcpy(dest2, src, size);
+
+    for (size_t i = 0; i < size; ++i) {
+        if (*dest1 != *dest2) {
+            free(dest1);
+            free(dest2);
+            return 0;
+        }
+    }
+
+    free(dest1);
+    free(dest2);
+
+    return 1;
 }

--- a/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
+++ b/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
@@ -16,6 +16,11 @@ int main() {
 
 	char *dest_str = malloc(sizeof(src));
 	char *dest_mem = malloc(sizeof(src));
+	
+	if (!dest_str || !dest_mem) {
+		perror("malloc() failed");
+		return 1;
+	}
 
 	(void) s1;
 	(void) s2;

--- a/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
+++ b/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
@@ -14,8 +14,8 @@ int main() {
 	char s2[] = "Abracababra";
 	char src[] = "Learn IOCLA, you must!";
 
-	char* dest_strcpy = malloc(sizeof(src));
-	char* dest_memcpy = malloc(sizeof(src));
+	char *dest_str = malloc(sizeof(src));
+	char *dest_mem = malloc(sizeof(src));
 
 	(void) s1;
 	(void) s2;
@@ -26,10 +26,10 @@ int main() {
 	cu succes. In caz contrar, programul va crapa.
 	*/
 	// assert(SIGN(my_strcmp(s1, s2)) == SIGN(strcmp(s1, s2)));
-	// assert(strcpy(dest_strcpy, src) && !strcmp(src, dest_strcpy));
-	// assert(my_memcpy(dest_memcpy, src, sizeof(src)) && !memcmp(src, dest_memcpy, sizeof(src)));
+	// assert(strcpy(dest_str, src) && !strcmp(dest_str, src));
+	// assert(my_memcpy(dest_mem, src, sizeof(src)) && !memcmp(dest_mem, src, sizeof(src)));
 
-	free(dest_strcpy);
-	free(dest_memcpy);
+	free(dest_str);
+	free(dest_mem);
 	return 0;
 }

--- a/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
+++ b/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
@@ -5,10 +5,6 @@
 
 #define SIGN(X) (((X) > 0) - ((X) < 0))
 
-int test_strcpy(const char *src, size_t size);
-int test_memcpy(const char *src, size_t size);
-
-
 int my_strcmp(const char *s1, const char *s2);
 void *my_memcpy(void *dest, const void *src, size_t n);
 char *my_strcpy(char *dest, const char *src);
@@ -17,6 +13,9 @@ int main() {
 	char s1[] = "Abracadabra";
 	char s2[] = "Abracababra";
 	char src[] = "Learn IOCLA, you must!";
+
+	char* dest_strcpy = malloc(sizeof(src));
+	char* dest_memcpy = malloc(sizeof(src));
 
 	(void) s1;
 	(void) s2;
@@ -27,51 +26,10 @@ int main() {
 	cu succes. In caz contrar, programul va crapa.
 	*/
 	// assert(SIGN(my_strcmp(s1, s2)) == SIGN(strcmp(s1, s2)));
-	// assert(test_strcpy(src, sizeof(src)));
-	// assert(test_memcpy(src, sizeof(src)));
+	// assert(strcpy(dest_strcpy, src) && !strcmp(src, dest_strcpy));
+	// assert(my_memcpy(dest_memcpy, src, sizeof(src)) && !memcmp(src, dest_memcpy, sizeof(src)));
 
+	free(dest_strcpy);
+	free(dest_memcpy);
 	return 0;
-}
-
-
-/* USED FOR TESTING! DO NOT MODIFY! */
-
-int test_strcpy(const char *src, size_t size) {
-	char *dest1 = malloc(size);
-	char *dest2 = malloc(size);
-
-	strcpy(dest1, src);
-	my_strcpy(dest2, src);
-
-	if (strcmp(dest1, dest2)) {
-		free(dest1);
-		free(dest2);
-		return 0;
-	}
-
-	free(dest1);
-	free(dest2);
-
-	return 1;
-}
-
-int test_memcpy(const char *src, size_t size) {
-	char *dest1 = malloc(size);
-	char *dest2 = malloc(size);
-
-	memcpy(dest1, src, size);
-	my_memcpy(dest2, src, size);
-
-	for (size_t i = 0; i < size; ++i) {
-		if (*dest1 != *dest2) {
-			free(dest1);
-			free(dest2);
-			return 0;
-		}
-	}
-
-	free(dest1);
-	free(dest2);
-
-	return 1;
 }

--- a/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
+++ b/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
@@ -14,64 +14,64 @@ void *my_memcpy(void *dest, const void *src, size_t n);
 char *my_strcpy(char *dest, const char *src);
 
 int main() {
-    char s1[] = "Abracadabra";
-    char s2[] = "Abracababra";
-    char src[] = "Learn IOCLA, you must!";
+	char s1[] = "Abracadabra";
+	char s2[] = "Abracababra";
+	char src[] = "Learn IOCLA, you must!";
 
-    (void) s1;
-    (void) s2;
+	(void) s1;
+	(void) s2;
 
-    /*
-    Decomentati pe rand cate un assert pe masura ce implementati o functie.
-    Daca functia voastra este implementata corect atunci asertia se va realiza
-    cu succes. In caz contrar, programul va crapa.
-    */
-    // assert(SIGN(my_strcmp(s1, s2)) == SIGN(strcmp(s1, s2)));
-    // assert(test_strcpy(src, sizeof(src)));
-    // assert(test_memcpy(src, sizeof(src)));
+	/*
+	Decomentati pe rand cate un assert pe masura ce implementati o functie.
+	Daca functia voastra este implementata corect atunci asertia se va realiza
+	cu succes. In caz contrar, programul va crapa.
+	*/
+	// assert(SIGN(my_strcmp(s1, s2)) == SIGN(strcmp(s1, s2)));
+	// assert(test_strcpy(src, sizeof(src)));
+	// assert(test_memcpy(src, sizeof(src)));
 
-    return 0;
+	return 0;
 }
 
 
 /* USED FOR TESTING! DO NOT MODIFY! */
 
 int test_strcpy(const char *src, size_t size) {
-    char *dest1 = malloc(size);
-    char *dest2 = malloc(size);
+	char *dest1 = malloc(size);
+	char *dest2 = malloc(size);
 
-    strcpy(dest1, src);
-    my_strcpy(dest2, src);
+	strcpy(dest1, src);
+	my_strcpy(dest2, src);
 
-    if (strcmp(dest1, dest2)) {
-        free(dest1);
-        free(dest2);
-        return 0;
-    }
+	if (strcmp(dest1, dest2)) {
+		free(dest1);
+		free(dest2);
+		return 0;
+	}
 
-    free(dest1);
-    free(dest2);
+	free(dest1);
+	free(dest2);
 
-    return 1;
+	return 1;
 }
 
 int test_memcpy(const char *src, size_t size) {
-    char *dest1 = malloc(size);
-    char *dest2 = malloc(size);
+	char *dest1 = malloc(size);
+	char *dest2 = malloc(size);
 
-    memcpy(dest1, src, size);
-    my_memcpy(dest2, src, size);
+	memcpy(dest1, src, size);
+	my_memcpy(dest2, src, size);
 
-    for (size_t i = 0; i < size; ++i) {
-        if (*dest1 != *dest2) {
-            free(dest1);
-            free(dest2);
-            return 0;
-        }
-    }
+	for (size_t i = 0; i < size; ++i) {
+		if (*dest1 != *dest2) {
+			free(dest1);
+			free(dest2);
+			return 0;
+		}
+	}
 
-    free(dest1);
-    free(dest2);
+	free(dest1);
+	free(dest2);
 
-    return 1;
+	return 1;
 }

--- a/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
+++ b/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
@@ -16,7 +16,7 @@ int main() {
 
 	char *dest_str = malloc(sizeof(src));
 	char *dest_mem = malloc(sizeof(src));
-	
+
 	if (!dest_str || !dest_mem) {
 		perror("malloc() failed");
 		return 1;


### PR DESCRIPTION
Added two testing functions, test_strcpy and test_memcpy, which are now called by the asserts, instead of calling the functions to be tested directly. Now, the condition for failure is for the destination data to be different, not just the pointers.