### PR TITLE
lab/memory-gdb: Replace `strcpy` with `my_strcpy`: Fixes #121

### DIFF
--- a/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
+++ b/laborator/content/operatii-memorie-gdb/7-pointers/pointers.c
@@ -31,7 +31,7 @@ int main() {
 	cu succes. In caz contrar, programul va crapa.
 	*/
 	// assert(SIGN(my_strcmp(s1, s2)) == SIGN(strcmp(s1, s2)));
-	// assert(strcpy(dest_str, src) && !strcmp(dest_str, src));
+	// assert(my_strcpy(dest_str, src) && !strcmp(dest_str, src));
 	// assert(my_memcpy(dest_mem, src, sizeof(src)) && !memcmp(dest_mem, src, sizeof(src)));
 
 	free(dest_str);


### PR DESCRIPTION
`strcpy` in the second assert was changed to `my_strcpy`, otherwise the exercise would have been pointless.