### PR TITLE
lab/number-representation: Explain the need to cast parameters to `void`

### DIFF
--- a/laborator/content/reprezentare-numere/2-len_xor/len_xor.c
+++ b/laborator/content/reprezentare-numere/2-len_xor/len_xor.c
@@ -5,6 +5,13 @@
 int my_strlen(const char *str)
 {
 	/* TODO */
+
+	/**
+	 * The cast to (void) is used to avoid a compiler warning. Remove the line
+	 * below to find out what the warning is.
+	 *
+	 * Remove this cast when implementing the function.
+	 */
 	(void) str;
 
 	return -1;


### PR DESCRIPTION
Fixes #148.