### PR TITLE
lab/etapele-compilarii: Ex 6 Changed Makefile

### DIFF
--- a/laborator/content/etapele-compilarii/06-obj-link-dev/Makefile
+++ b/laborator/content/etapele-compilarii/06-obj-link-dev/Makefile
@@ -1,2 +1,15 @@
-PROGNAME := main
-include ../../utils/Makefile.generic
+CC = gcc
+CFLAGS = -g -Wall -Wextra -Werror -fno-pic -masm=intel
+
+.PHONY: all clean
+
+all: main
+
+
+# TODO: Add dependecies here so that the Makefile works
+main: main.c
+	$(CC) $(CFLAGS) -o $@ $^
+
+
+clean:
+	-rm -f main main.o

--- a/laborator/content/etapele-compilarii/README.md
+++ b/laborator/content/etapele-compilarii/README.md
@@ -443,6 +443,9 @@ Editați fișierul `main.c` pentru a apela corespunzător interfața expusă și
 price is 21
 quantity is 42
 ```
+> **NOTE:**
+> Pentru a putea folosi comanda `make` la acest exercițiu va trebui să completați fișierul `Makefile` pentru a realiza linkarea cu interfața
+> `shop.o` (trebuie tratată ca o bibliotecă externă)
 
 Explorați interfața și conținutul funcțiilor din fisierul `shop.o` folosind `nm` și `objdump`.
 

--- a/laborator/content/etapele-compilarii/README.md
+++ b/laborator/content/etapele-compilarii/README.md
@@ -444,8 +444,7 @@ price is 21
 quantity is 42
 ```
 > **NOTE:**
-> Pentru a putea folosi comanda `make` la acest exercițiu va trebui să completați fișierul `Makefile` pentru a realiza linkarea cu interfața
-> `shop.o` (trebuie tratată ca o bibliotecă externă)
+> Pentru a putea folosi comanda `make` la acest exercițiu va trebui să completați fișierul `Makefile` pentru a realiza linkarea cu fișierul obiect `shop.o`
 
 Explorați interfața și conținutul funcțiilor din fisierul `shop.o` folosind `nm` și `objdump`.
 


### PR DESCRIPTION
On ex 6:
- Changed Makefile
- Ex 6 requires the students to call functions from 'shop.o' interface
- The old Makefile is a generic one that (at least in my case) doesn't link with 'shop.o'
- The one I added has a 'To Do' for students to complete it, so it links with 'shop.o'
- It will make them look out for Makefile properties or ask