### PR TITLE
lab/struct: Improve printf formatting

### DIFF
--- a/laborator/content/structuri-vectori-siruri/0-fibonacci/fibo-sum.asm
+++ b/laborator/content/structuri-vectori-siruri/0-fibonacci/fibo-sum.asm
@@ -2,8 +2,7 @@
 
 section .data
     N dd 9 ; compute the sum of the first N fibonacci numbers
-    print_format_1 db "Sum first %d", 10, 0
-    print_format_2 db "fibo is %d", 10, 0
+    sum_print_format db "Sum first %d fibonacci numbers is %d", 10, 0
 
 section .text
 extern printf
@@ -12,11 +11,6 @@ main:
     push ebp
     mov ebp, esp
 
-    push dword [N]
-    push print_format_1
-    call printf
-    add esp, 8
-
     ; TODO: calculate the sum of first N fibonacci numbers
     ;       (f(0) = 0, f(1) = 1)
     xor eax, eax     ;store the sum in eax
@@ -24,9 +18,10 @@ main:
     ; use loop instruction
 
     push eax
-    push print_format_2
+    push dword [N]
+    push sum_print_format
     call printf
-    add esp, 8
+    add esp, 12
 
     xor eax, eax
     leave

--- a/laborator/content/structuri-vectori-siruri/1-2-print-structure/print-structure.asm
+++ b/laborator/content/structuri-vectori-siruri/1-2-print-structure/print-structure.asm
@@ -10,10 +10,6 @@ struc stud_struct
 endstruc
 
 section .data
-    string_format db "%s", 0
-    string_endline_format db "%s", 10, 0
-    dec_format db "%d", 10, 0
-
 sample_student:
     istruc stud_struct
         at name, db 'Andrei', 0
@@ -24,12 +20,12 @@ sample_student:
         at birth_year, dw 1994
     iend
 
-string_name db "Name: ", 0
-string_surname db "Surname: ", 0
-string_age db "Age: ", 0
-string_group db "Group: ", 0
-string_gender db "Gender: ", 0
-string_year db "Birth year: ", 0
+format_name db "Name: %s", 10, 0
+format_surname db "Surname: %s", 10, 0
+format_age db "Age: %d", 10, 0
+format_group db "Group: %s", 10, 0
+format_gender db "Gender: %d", 10, 0
+format_year db "Birth year: %d", 10, 0
 
 section .text
 extern printf
@@ -43,75 +39,39 @@ main:
     ; age is 22
     ; group is '323CA'
 
-    lea ebx, [string_name]
-    push ebx
-    push string_format
-    call printf
-    add esp, 8
     lea eax, [sample_student + name]
     push eax
-    push string_endline_format
+    push format_name
     call printf
     add esp, 8
 
-    lea ebx, [string_surname]
-    push ebx
-    push string_format
-    call printf
-    add esp, 8
     lea eax, [sample_student + surname]
     push eax
-    push string_endline_format
+    push format_surname
     call printf
     add esp, 8
 
-    lea ebx, [string_age]
-    push ebx
-    push string_format
-    call printf
-    add esp, 8
-    mov al, byte [sample_student + age]
-    xor ebx, ebx
-    mov bl, al
-    push ebx
-    push dec_format
+    movzx eax, byte [sample_student + age]
+    push eax
+    push format_age
     call printf
     add esp, 8
 
-    lea ebx, [string_group]
-    push ebx
-    push string_format
-    call printf
-    add esp, 8
     lea eax, [sample_student + group]
     push eax
-    push string_endline_format
+    push format_group
     call printf
     add esp, 8
 
-    lea ebx, [string_gender]
-    push ebx
-    push string_format
-    call printf
-    add esp, 8
-    mov al, byte [sample_student + gender]
-    xor ebx, ebx
-    mov bl, al
-    push ebx
-    push dec_format
+    movzx eax, byte [sample_student + gender]
+    push eax
+    push format_gender
     call printf
     add esp, 8
 
-    lea ebx, [string_year]
-    push ebx
-    push string_format
-    call printf
-    add esp, 8
-    mov ax, [sample_student + birth_year]
-    xor ebx, ebx
-    mov bx, ax
-    push ebx
-    push dec_format
+    movzx eax, word [sample_student + birth_year]
+    push eax
+    push format_year
     call printf
     add esp, 8
 


### PR DESCRIPTION
The old prints used multiple calls to `printf` to output a single line of information. These changes are meant to make reading the code easier by reducing the number of lines required to print the data.