### PR TITLE
lab/assembly-intro: Fix `cf-of` exercise

### DIFF
--- a/laborator/content/introducere-asamblare/7-cf-of/cf_of.asm
+++ b/laborator/content/introducere-asamblare/7-cf-of/cf_of.asm
@@ -5,16 +5,20 @@ section .text
     extern printf
 
 main:
-    mov al, 0xDE
+    mov al, 128
     PRINTF32 `CF si OF nu sunt active\n\x0`
     test al, al
     ;TODO: activati CF si OF
 
-    jz cf_of_on
+    jc cf_on
+    jmp end
+
+cf_on:
+    jo cf_of_on
     jmp end
 
 cf_of_on:
-    PRINTF32 `CF si OF activ\n\x0`
+    PRINTF32 `CF si OF active\n\x0`
 
 end:
     ret

--- a/laborator/content/introducere-asamblare/solution/7-cf-of/cf_of.asm
+++ b/laborator/content/introducere-asamblare/solution/7-cf-of/cf_of.asm
@@ -6,11 +6,18 @@ section .text
 
 main:
 
-    mov al, 0xDE
+    mov al, 128
     PRINTF32 `CF si OF nu sunt active\n\x0`
     test al, al
-    add al, 0x22
-    jz cf_of_on
+
+    ; Orice valoare intre 128 si 255 va activa CF si OF
+    add al, 128
+
+    jc cf_on
+    jmp end
+
+cf_on:
+    jo cf_of_on
     jmp end
 
 cf_of_on:


### PR DESCRIPTION
The skeleton code was checking ZF and not CF and OF.