### PR TITLE
Syntax fix in lab and makefile rule for running compiled program

### DIFF
--- a/laborator/content/reprezentare-numere/demo/pointers/pointers-demo.c
+++ b/laborator/content/reprezentare-numere/demo/pointers/pointers-demo.c
@@ -20,7 +20,7 @@ int main(void)
 	p = p + 4;
 	printf("p : %p\n", p);
 
-	*p = &var;
+	*p = (int) &var;
 	printf("p : %p\n", &p);
 	printf("var : 0x%08x\n", var);
 

--- a/laborator/content/utils/Makefile.generic
+++ b/laborator/content/utils/Makefile.generic
@@ -1,6 +1,8 @@
 PROGNAME ?= a.out
 
 build: $(PROGNAME)
+run: build
+	./$(PROGNAME)
 
 UTILSDIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(UTILSDIR)/Makefile.inc


### PR DESCRIPTION
- Added a cast from pointer to int (no implicit conversion)
- Fixed missing rule for running in generic makefile