### PR TITLE
Change lab01 rotation functions parameter type

### DIFF
--- a/laborator/content/reprezentare-numere/4-rotations/rotations.c
+++ b/laborator/content/reprezentare-numere/4-rotations/rotations.c
@@ -1,13 +1,13 @@
 #include <stdio.h>
 
-void rotate_left(int *number, int bits)
+void rotate_left(unsigned int *number, int bits)
 {
 	/* TODO */
 	(void) number;
 	(void) bits;
 }
 
-void rotate_right(int *number, int bits)
+void rotate_right(unsigned int *number, int bits)
 {
 	/* TODO */
 	(void) number;

--- a/laborator/content/reprezentare-numere/solution/4-rotations/rotations.c
+++ b/laborator/content/reprezentare-numere/solution/4-rotations/rotations.c
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 
-void rotate_left(int *number, int bits)
+void rotate_left(unsigned int *number, int bits)
 {
 	unsigned int bit_mask = -1;
 
@@ -13,7 +13,7 @@ void rotate_left(int *number, int bits)
 	(*number) |= bit_mask;
 }
 
-void rotate_right(int *number, int bits)
+void rotate_right(unsigned int *number, int bits)
 {
 	unsigned int bit_mask = -1;
 
@@ -26,7 +26,7 @@ void rotate_right(int *number, int bits)
 
 int main(void)
 {
-	int number;
+	unsigned int number;
 
 	number = 0x80000000;
 	rotate_left(&number, 1);


### PR DESCRIPTION
Use `unsigned int` instead of `int` for bitwise rotate functions. The reason for this change is that signed integers should generally not be used as bitsets, since some arithmetic operators behave badly in the case of signed integers, as opposed to unsigned (particularly left and right shifts). Here, the problems with `int` arise in the following ways:
- The proposed solution assigns the unsigned constant `0x80000000`, with value `2^31`, to a 32-bit signed integer, which can only represent values less than or equal to `2^31 - 1`. Assigning this large value to an `int` has implementation-defined behavior. Legal signed integer values with this particular bit representation (`1` followed by 31 zeros) include two's complement `-2^31`, sign-and-magnitude `-0` etc. (depending on the encoding).
- The proposed `rotate_left` impl shifts signed `*number` to the left by `bits` positions, though the C standard document specifies the result of this operation is `*number * 2^(bits)`, and if this value is not representable by `int`, then the behavior is undefined (this happens whenever a `1` is shifted to or beyond the most significant bit).
- The proposed `rotate_right` impl similarly shifts signed `*number` to the right by `bits` positions, adding the missing piece to the left by way of the `|` operator. The assumption is that the shift leaves some `0` bits to the left of `*number`. However, if the most significant bit is `1` (i.e., a negative value), the result of the right shift is implementation-defined. Modern platforms implement arithmetic right shift, which extends the sign of `*number` by copying the most significant bit, leaving `1` instead of `0` to the left side of `*number`.

All of these problems can be avoided by using unsigned numbers instead, as they do not exhibit strange behavior with bit operators. Note that using signed integers for the right-hand operands of shift operators is not a problem, hence I left the `bits` parameter untouched.