### PR TITLE
Add parentheses to lab-02 get pixel macro

### DIFF
--- a/laborator/content/operatii-memorie-gdb/README.md
+++ b/laborator/content/operatii-memorie-gdb/README.md
@@ -460,7 +460,7 @@ p.b = 0.11 * p.b;
 > Accesarea elementelor matricei de pixeli se va face folosind operații cu pointeri.
 > **Hint:** Pentru simplificare, vă puteți folosi de urmatorul macro:
 > ```c
-> #define GET_PIXEL(a, i ,j) (*(*(a + i) + j))
+> #define GET_PIXEL(a, i ,j) (*(*((a) + (i)) + (j)))
 > ```
 
 ### **4. Find-Max**

--- a/laborator/content/operatii-memorie-gdb/solution/3-pixels/pixels.c
+++ b/laborator/content/operatii-memorie-gdb/solution/3-pixels/pixels.c
@@ -7,7 +7,7 @@
 #include <time.h>
 #include "pixel.h"
 
-#define GET_PIXEL(a, i, j) (*(*(a + i) + j))
+#define GET_PIXEL(a, i, j) (*(*((a) + (i)) + (j)))
 
 void colorToGray(Picture *pic)
 {


### PR DESCRIPTION
Add parentheses around function-like macro parameters to avoid surprises with operator precedence. For instance: `GET_PIXEL(a, 1<<2, 0)`.