### PR TITLE
Fix pixels reverse solution to use width for swapRows

### DIFF
--- a/laborator/content/operatii-memorie-gdb/solution/3-pixels/pixels.c
+++ b/laborator/content/operatii-memorie-gdb/solution/3-pixels/pixels.c
@@ -34,7 +34,7 @@ void reversePic(Picture *pic)
 {
 	for (int i = 0; i < pic->height / 2; ++i)
 		swapRows(pic->pix_array[i], pic->pix_array[pic->height - 1 - i],
-				pic->height);
+				pic->width);
 }
 
 int main(void)


### PR DESCRIPTION
The proposed solution for reversePic erroneously passes the height of the image to the ancillary function that swaps rows. Updated to use width instead.